### PR TITLE
Fix off-by-one error in kbdneo2.c

### DIFF
--- a/windows/kbdneo2/Quelldateien/kbdneo2.c
+++ b/windows/kbdneo2/Quelldateien/kbdneo2.c
@@ -189,7 +189,7 @@ static ALLOC_SECTION_LDATA VK_TO_BIT aVkToBits[] = {
 
 static ALLOC_SECTION_LDATA MODIFIERS CharModifiers = {
 	&aVkToBits[0],
-	25, //Anzahl der verwendeten Ebenen (inklusive der INVALIDen!)
+	24, // Maximaler Wert, den die Modifier-Bitmaske annehmen kann
 	{
 	//  Modifier NEO 
 	//  Ebene 0 - nix


### PR DESCRIPTION
kbdneo2 hat einen Off-By-One-Fehler in der MODIFIERS-Definition.

wMaxModBits soll laut Spezifikation (kbd.h) den *maximalen Wert* angeben, den die bitweise Kombination von Modifiern erreichen kann. NICHT die *Anzahl* der Werte. Die Angabe ist hier also um eins zu hoch.

Scheint Windows zwar bisher nicht weiter gestört zu haben, hat [meinen Code](https://gitlab.gnome.org/GNOME/gtk/merge_requests/1051) aber gestört und ich musste einen Workaround dafür einbauen. Der ist zwar jetzt eh drin, insofern ist es nicht so kritisch, aber man könnte das bei Gelegenheit mal beheben.